### PR TITLE
Fix to display error message to stdout

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -130,7 +130,7 @@ func standAloneMode() {
 
 	nicoerr := l.FetchInformation()
 	if nicoerr != nil {
-		log.Fatalln(nicoerr)
+		log.Fatalln(nicoerr.Error())
 	}
 
 	commconn := nicolive.NewCommentConnection(&l, nil)


### PR DESCRIPTION
log.FatalLn(nicoerr) didn't display error message to stdout even if error happens in l.FetchInformation().
This is why I fixed this line to display error message by using Error() method.
But I'm not sure that this way is best way. Because Error() method shows go file name too.
If you have any idea for fixing this, please do that.
